### PR TITLE
Mention that CONTRIBUTORS.txt doesn't apply to all repos

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -17,9 +17,10 @@
 - [ ] I think the code is well written
 - [ ] Unit tests for the changes exist
 - [ ] Documentation reflects the changes
-- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
+- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (if applicable)
   * The format is `<Name> <Surname>`.
   * Please keep alphabetical order, the file is sorted by names. 
+  * This can be skipped if there is no `CONTRIBUTORS.txt` in the repo
 - [ ] Add a new news fragment into the `CHANGES` folder
   * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
   * if you don't have an `issue_id` change it to the pr id after creating the PR


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

In Global PR template, mention that the CONTRIBUTORS.txt doesn't always exist.
It can be skipped/ignored if there is no such file.

## Are there changes in behavior for the user?

Contributors will see a different PR template

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
