### PR TITLE
Remove CONTRIBUTORS.txt check in Global PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -17,9 +17,6 @@
 - [ ] I think the code is well written
 - [ ] Unit tests for the changes exist
 - [ ] Documentation reflects the changes
-- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
-  * The format is `<Name> <Surname>`.
-  * Please keep alphabetical order, the file is sorted by names. 
 - [ ] Add a new news fragment into the `CHANGES` folder
   * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
   * if you don't have an `issue_id` change it to the pr id after creating the PR


### PR DESCRIPTION
Remove CONTRIBUTORS.txt check in the Global PR template.

Alternative solution to #2 